### PR TITLE
removed click binding from select drop down to prevent double alert fire...

### DIFF
--- a/js/main.js
+++ b/js/main.js
@@ -49,7 +49,7 @@ var POSTFINDERTEMPLATE = [//Very specific name so as to not be overwritten accid
 			// bind select
 			console.log("select", plugin.$select);
 			console.log("select", plugin.settings.selectSelector);
-			plugin.$select.on('change click', function(e){
+			plugin.$select.on('change', function(e){
 				add_item( $(this).val(), $('option:selected', this).text() );
 			});
 


### PR DESCRIPTION
removed click binding from select drop down to prevent double alert fireing in safari
